### PR TITLE
Dtype file support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "av>=13.1.0",
-    "numpy>=2.1.2",
+    "av",
+    "numpy",
     "pupil-labs-video",
     "pupil-labs-matching",
     "structlog>=24.4.0",

--- a/src/pupil_labs/neon_recording/arrayrecord.py
+++ b/src/pupil_labs/neon_recording/arrayrecord.py
@@ -1,0 +1,157 @@
+from ast import literal_eval
+from functools import partial
+from pathlib import Path
+from re import compile as re_compile
+from typing import (
+    Callable,
+    Generic,
+    Iterable,
+    SupportsIndex,
+    TypeVar,
+    overload,
+)
+
+import numpy as np
+import numpy.typing as npt
+
+RecordT = TypeVar("RecordT", bound=np.record)
+
+
+ArraySource = str | Path | np.ndarray | bytes
+
+
+def natural_sort_key(word):
+    if isinstance(word, Path):
+        word = word.name
+    if isinstance(word, str):
+        return tuple([
+            int(text) if text.isdigit() else text.lower()
+            for text in re_compile(r"(\d+)").split(word)
+        ])
+    return word
+
+
+class Record(np.record):
+    def __new__(cls, source: str | Path | np.ndarray | bytes):
+        return Array.load_arrays(source, cls.dtype)[0].view(cls)
+
+    def items(self):
+        return [(k, self[k]) for k in self.dtype.fields]
+
+    def __repr__(self):
+        lines = []
+        pad = "    "
+        n = max(len(key) for key in self.dtype.fields)
+        for k, v in self.items():
+            v_repr_lines = repr(v).splitlines()
+            lines.append(f"{pad}{k:>{n}} = {v_repr_lines[0]}")
+            if len(v_repr_lines) > 1:
+                lines.extend(
+                    f"{pad + '  '}{n * ' '}{line}" for line in v_repr_lines[1:]
+                )
+        lines_string = "\n".join(lines)
+        lines_string = "\n" + lines_string + "\n"
+        return f"{self.__class__.__qualname__}({lines_string})"
+
+
+class Array(np.ndarray, Generic[RecordT]):
+    record_class: type = Record
+    dtype: np.dtype | None = None
+
+    def __init_subclass__(cls, record_class: type = Record):
+        cls.record_class = record_class
+        return super().__init_subclass__()
+
+    def __new__(
+        cls,
+        source: ArraySource | Iterable[ArraySource],
+        dtype: npt.DTypeLike = None,
+        fallback_dtype: npt.DTypeLike = None,
+    ):
+        data_dtype = dtype or cls.dtype or fallback_dtype
+        sources = cls.expand_source_arguments(source)
+        data = cls.load_arrays(sources, partial(cls.load_array, dtype=data_dtype))
+        return data.view(cls)
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.dtype = obj.dtype
+        return super().__array_finalize__(obj)
+
+    @overload
+    def __getitem__(self, key: SupportsIndex) -> RecordT: ...
+    @overload
+    def __getitem__(self, key: slice) -> "Array": ...
+    def __getitem__(self, key: SupportsIndex | slice) -> "Array | RecordT":
+        result = super().__getitem__(key)
+        if isinstance(result, np.void):
+            if self.__class__.record_class:
+                self.__class__.record_class.dtype = result.dtype
+                return result.view(self.__class__.record_class)
+            return result
+        elif isinstance(key, slice):
+            return result.view(self.__class__)
+        return np.array(result)  # type: ignore
+
+    @classmethod
+    def load_array(cls, source: str | Path | np.ndarray | bytes, dtype: npt.DTypeLike):
+        if isinstance(source, (str, Path)):
+            source_path = Path(source)
+            basename = source_path.stem.split(" ps")[0]
+            if source_path.suffix == ".raw":
+                dtype_file = source_path.parent / f"{basename}.dtype"
+                if dtype_file.exists():
+                    dtype = np.dtype(literal_eval(dtype_file.read_text()))
+        elif isinstance(source, np.ndarray):
+            dtype = source.dtype
+
+        if not dtype:
+            source_repr = (
+                source if isinstance(source, (str, Path)) else source.__class__.__name__
+            )
+
+            raise ValueError(f"dtype could not be found for {source_repr}")
+
+        if isinstance(source, (str, Path)):
+            data = np.fromfile(source, dtype=dtype)
+        elif isinstance(source, bytes):
+            data = np.frombuffer(source, dtype=dtype)
+        elif isinstance(source, np.ndarray):
+            data = source
+        return data
+
+    @classmethod
+    def load_arrays(
+        cls,
+        source: ArraySource | Iterable[ArraySource],
+        decoder: Callable[[ArraySource], np.ndarray],
+    ):
+        parts = []
+        parts_dtypes = set()
+        for item in cls.expand_source_arguments(source):
+            merged = decoder(item)
+            parts_dtypes.add(tuple(merged.dtype.descr))
+            if len(merged):
+                parts.append(merged)
+
+        if len(set(parts_dtypes)) > 1:
+            raise ValueError("found multiple dtypes")
+        if len(parts) == 1:
+            merged = parts[0]
+        elif len(parts) > 1:
+            merged = np.concatenate(parts)
+        else:
+            merged = np.array([], dtype=np.dtype(list(parts_dtypes.pop())))
+        return merged
+
+    @classmethod
+    def expand_source_arguments(cls, source: ArraySource | Iterable[ArraySource]):
+        sources = []
+        if isinstance(source, (str, Path, bytes, np.ndarray)):
+            sources.append(source)
+        elif isinstance(source, Iterable):
+            sources.extend(list(source))
+        else:
+            raise TypeError("unknown type")
+        return sorted(sources, key=natural_sort_key)

--- a/src/pupil_labs/neon_recording/eye_state.py
+++ b/src/pupil_labs/neon_recording/eye_state.py
@@ -6,11 +6,8 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from pupil_labs.neon_recording.arrayrecord import Array
 from pupil_labs.neon_recording.neon_timeseries import NeonTimeseries
-from pupil_labs.neon_recording.utils import (
-    find_sorted_multipart_files,
-    load_multipart_data_time_pairs,
-)
 from pupil_labs.video import ArrayLike
 
 
@@ -23,6 +20,9 @@ class EyeStateRecord(NamedTuple):
     pupil_diameter_right: float
     eyeball_center_right: npt.NDArray[np.float64]
     optical_axis_right: npt.NDArray[np.float64]
+
+    eyelid_angle: npt.NDArray[np.float64] | None = None
+    eyelid_aperture: npt.NDArray[np.float64] | None = None
 
     @property
     def abs_ts(self) -> int:
@@ -57,11 +57,26 @@ class EyeState(NeonTimeseries[EyeStateRecord]):
 
     @staticmethod
     def from_native_recording(rec_dir: Path, rec_start: int) -> "EyeState":
-        eye_state_files = find_sorted_multipart_files(rec_dir, "eye_state")
-        eye_state_data, time_data = load_multipart_data_time_pairs(
-            eye_state_files, "<f4", 2
+        eye_state_data = Array(
+            rec_dir.glob("eye_state ps*.raw"),
+            fallback_dtype=np.dtype([
+                ("pupil_diameter_left_mm", "float32"),
+                ("eyeball_center_left_x", "float32"),
+                ("eyeball_center_left_y", "float32"),
+                ("eyeball_center_left_z", "float32"),
+                ("optical_axis_left_x", "float32"),
+                ("optical_axis_left_y", "float32"),
+                ("optical_axis_left_z", "float32"),
+                ("pupil_diameter_right_mm", "float32"),
+                ("eyeball_center_right_x", "float32"),
+                ("eyeball_center_right_y", "float32"),
+                ("eyeball_center_right_z", "float32"),
+                ("optical_axis_right_x", "float32"),
+                ("optical_axis_right_y", "float32"),
+                ("optical_axis_right_z", "float32"),
+            ]),
         )
-        eye_state_data = eye_state_data.reshape(-1, 14)
+        time_data = Array(rec_dir.glob("eye_state ps*.time"), np.int64)
         return EyeState(time_data, eye_state_data, rec_start)
 
     @property
@@ -74,31 +89,81 @@ class EyeState(NeonTimeseries[EyeStateRecord]):
 
     @property
     def pupil_diameters(self) -> npt.NDArray[np.float64]:
-        return self._data[:, [0, 7]]
+        return self._data[["pupil_diameter_left_mm", "pupil_diameter_right_mm"]]
 
     @property
     def pupil_diameter_left(self) -> npt.NDArray[np.float64]:
-        return self._data[:, 0]
+        return self._data["pupil_diameter_left_mm"]
 
     @property
     def pupil_diameter_right(self) -> npt.NDArray[np.float64]:
-        return self._data[:, 7]
+        return self._data["pupil_diameter_right_mm"]
 
     @property
     def eyeball_center_left(self) -> npt.NDArray[np.float64]:
-        return self._data[:, [1, 2, 3]]
+        return self._data[
+            [
+                "eyeball_center_left_x",
+                "eyeball_center_left_y",
+                "eyeball_center_left_z",
+            ]
+        ]
 
     @property
     def eyeball_center_right(self) -> npt.NDArray[np.float64]:
-        return self._data[:, [8, 9, 10]]
+        return self._data[
+            [
+                "eyeball_center_right_x",
+                "eyeball_center_right_y",
+                "eyeball_center_right_z",
+            ]
+        ]
 
     @property
     def optical_axis_left(self) -> npt.NDArray[np.float64]:
-        return self._data[:, [4, 5, 6]]
+        return self._data[
+            [
+                "optical_axis_left_x",
+                "optical_axis_left_y",
+                "optical_axis_left_z",
+            ]
+        ]
 
     @property
     def optical_axis_right(self) -> npt.NDArray[np.float64]:
-        return self._data[:, [11, 12, 13]]
+        return self._data[
+            [
+                "optical_axis_right_x",
+                "optical_axis_right_y",
+                "optical_axis_right_z",
+            ]
+        ]
+
+    @property
+    def eyelid_angle(self) -> npt.NDArray[np.float64]:
+        if "eyelid_angle_top_left" not in self._data.dtype.fields:
+            return None
+
+        return self._data[
+            [
+                "eyelid_angle_top_left",
+                "eyelid_angle_bottom_left",
+                "eyelid_angle_top_right",
+                "eyelid_angle_bottom_right",
+            ]
+        ]
+
+    @property
+    def eyelid_aperture(self) -> npt.NDArray[np.float64]:
+        if "eyelid_aperture_mm_left" not in self._data.dtype.fields:
+            return None
+
+        return self._data[
+            [
+                "eyelid_aperture_mm_left",
+                "eyelid_aperture_mm_right",
+            ]
+        ]
 
     @property
     def data(self) -> npt.NDArray[np.float64]:
@@ -116,12 +181,14 @@ class EyeState(NeonTimeseries[EyeStateRecord]):
             record = EyeStateRecord(
                 self.abs_timestamps[key],
                 self.rel_timestamps[key],
-                self._data[key, 0],
-                self._data[key, 1:4],
-                self._data[key, 4:7],
-                self._data[key, 7],
-                self._data[key, 8:11],
-                self._data[key, 11:14],
+                self.pupil_diameter_left[key],
+                self.eyeball_center_left[key],
+                self.optical_axis_left[key],
+                self.pupil_diameter_right[key],
+                self.eyeball_center_right[key],
+                self.optical_axis_right[key],
+                None if self.eyelid_angle is None else self.eyelid_angle[key],
+                None if self.eyelid_aperture is None else self.eyelid_aperture[key],
             )
             return record
         else:
@@ -133,46 +200,14 @@ class EyeState(NeonTimeseries[EyeStateRecord]):
 
     def interpolate(self, timestamps: ArrayLike[int]) -> "EyeState":
         timestamps = np.array(timestamps)
-        interp_data: list[npt.NDArray[np.float64]] = []
-
-        for data_source in [
-            self.pupil_diameter_left,
-            self.eyeball_center_left,
-            self.optical_axis_left,
-            self.pupil_diameter_right,
-            self.eyeball_center_right,
-            self.optical_axis_right,
-        ]:
-            if data_source.ndim == 1:
-                d = np.interp(timestamps, self.abs_timestamps, data_source)
-                interp_data.append(d)
-            else:
-                for dim in range(data_source.shape[1]):
-                    interp_dim = np.interp(
-                        timestamps, self.abs_timestamps, data_source[:, dim]
-                    )
-                    interp_data.append(interp_dim)
-        interp_arr = np.column_stack(interp_data)
+        interp_arr = np.array(
+            [
+                np.interp(timestamps, self.abs_timestamps, self._data[k])
+                for k in self._data.dtype.fields
+            ],
+            dtype=self._data.dtype,
+        )
         return EyeState(timestamps, interp_arr, self._rec_start)
 
     def to_dataframe(self) -> pd.DataFrame:
-        return pd.DataFrame(
-            self._data,
-            columns=[
-                "pupil_diameter_left",
-                "eye_ball_center_left_x",
-                "eye_ball_center_left_y",
-                "eye_ball_center_left_z",
-                "optical_axis_left_x",
-                "optical_axis_left_y",
-                "optical_axis_left_z",
-                "pupil_diameter_right",
-                "eye_ball_center_right_x",
-                "eye_ball_center_right_y",
-                "eye_ball_center_right_z",
-                "optical_axis_right_x",
-                "optical_axis_right_y",
-                "optical_axis_right_z",
-            ],
-            index=self._time_data,
-        )
+        return pd.DataFrame(self._data, index=self._time_data)

--- a/src/pupil_labs/neon_recording/eye_state.py
+++ b/src/pupil_labs/neon_recording/eye_state.py
@@ -5,6 +5,7 @@ from typing import Iterator, NamedTuple, overload
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+
 from pupil_labs.neon_recording.neon_timeseries import NeonTimeseries
 from pupil_labs.neon_recording.utils import (
     find_sorted_multipart_files,
@@ -33,16 +34,14 @@ class EyeStateRecord(NamedTuple):
 
     @property
     def data(self) -> npt.NDArray[np.float64]:
-        return np.concatenate(
-            [
-                [self.abs_ts, self.pupil_diameter_left],
-                self.eyeball_center_left,
-                self.optical_axis_left,
-                [self.pupil_diameter_right],
-                self.eyeball_center_right,
-                self.optical_axis_right,
-            ]
-        )
+        return np.concatenate([
+            [self.abs_ts, self.pupil_diameter_left],
+            self.eyeball_center_left,
+            self.optical_axis_left,
+            [self.pupil_diameter_right],
+            self.eyeball_center_right,
+            self.optical_axis_right,
+        ])
 
 
 class EyeState(NeonTimeseries[EyeStateRecord]):

--- a/src/pupil_labs/neon_recording/gaze.py
+++ b/src/pupil_labs/neon_recording/gaze.py
@@ -5,6 +5,7 @@ from typing import Iterator, NamedTuple, overload
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+
 from pupil_labs.neon_recording.neon_timeseries import NeonTimeseries
 from pupil_labs.neon_recording.utils import (
     find_sorted_multipart_files,
@@ -85,12 +86,10 @@ class Gaze(NeonTimeseries[GazeRecord]):
 
     @property
     def data(self) -> npt.NDArray[np.float64]:
-        return np.column_stack(
-            (
-                self.abs_timestamps.astype(np.float64),
-                self._gaze_data,
-            )
-        )
+        return np.column_stack((
+            self.abs_timestamps.astype(np.float64),
+            self._gaze_data,
+        ))
 
     def __len__(self) -> int:
         return len(self._abs_timestamps)

--- a/src/pupil_labs/neon_recording/video_reader.py
+++ b/src/pupil_labs/neon_recording/video_reader.py
@@ -4,6 +4,7 @@ from typing import Sequence, overload
 
 import numpy as np
 import numpy.typing as npt
+
 import pupil_labs.video as plv
 from pupil_labs.neon_recording.frame import AudioFrame, VideoFrame
 from pupil_labs.neon_recording.frame_slice import FrameSlice

--- a/tests/test_neon_recording.py
+++ b/tests/test_neon_recording.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import pupil_labs.neon_recording as nr
@@ -19,3 +20,218 @@ def test_rec_info(rec: nr.NeonRecording):
     assert rec.duration_ns == 11013000000
     assert rec.duration_sec == 11.013
     assert rec.duration_ns * 1e-9 == rec.duration_sec
+
+def test_gaze(rec: nr.NeonRecording):
+    sensor = rec.gaze
+    ts = sensor.ts
+    assert len(sensor) == 1951
+
+    for a in list(sensor.sample(ts[1950]))[0]:
+        print(f"{a},")
+
+    target_0 = (
+        1726825502.652337,
+        740.6018676757812,
+        685.78662109375,
+    )
+    for a, b in zip(list(sensor.sample(ts[0]))[0], target_0):
+        assert a == b
+
+    target_100 = (
+        1726825503.3129618,
+        766.157958984375,
+        705.6735229492188,
+    )
+    for a, b in zip(list(sensor.sample(ts[100]))[0], target_100):
+        assert a == b
+
+    target_1950 = (
+        1726825512.576638,
+        1081.5859375,
+        1174.9180908203125,
+    )
+    for a, b in zip(list(sensor.sample(ts[1950]))[0], target_1950):
+        assert a == b
+
+
+def test_eye_state(rec: nr.NeonRecording):
+    sensor = rec.eye_state
+    ts = sensor.ts
+    assert len(sensor) == 1754
+
+    target_0 = (
+        1726825503.7984638,
+        5.107705593109131,
+        -29.4140625,
+        10.517578125,
+        -33.057861328125,
+        0.07107485830783844,
+        0.24335210025310516,
+        0.9673304557800293,
+        5.657186508178711,
+        33.5498046875,
+        12.3046875,
+        -33.194580078125,
+        -0.2051464319229126,
+        0.23124463856220245,
+        0.9510209560394287,
+    )
+    for a, b in zip(list(sensor.sample(ts[0]))[0], target_0):
+        assert a == b
+
+    target_100 = (
+        1726825504.298967,
+        5.102882385253906,
+        -29.677734375,
+        10.625,
+        -32.87841796875,
+        0.10377761721611023,
+        0.2530110478401184,
+        0.9618813395500183,
+        5.733665943145752,
+        33.291015625,
+        12.333984375,
+        -33.15185546875,
+        -0.17958272993564606,
+        0.24260810017585754,
+        0.9533579349517822,
+    )
+    for a, b in zip(list(sensor.sample(ts[100]))[0], target_100):
+        assert a == b
+
+    target_1753 = (
+        1726825512.576638,
+        5.204510688781738,
+        -28.88671875,
+        10.771484375,
+        -31.007080078125,
+        0.35248205065727234,
+        0.6131130456924438,
+        0.7069998383522034,
+        4.113816261291504,
+        33.8720703125,
+        12.67578125,
+        -35.211181640625,
+        0.10800117999315262,
+        0.6311267614364624,
+        0.7681241631507874,
+    )
+    for a, b in zip(list(sensor.sample(ts[1753]))[0], target_1753):
+        assert a == b
+
+
+def test_imu(rec: nr.NeonRecording):
+    sensor = rec.imu
+    ts = sensor.ts
+    assert len(sensor) == 1094
+
+    target_0 = (
+        1726825503.025795,
+        -1.39617919921875,
+        -5.626678466796875,
+        2.2525787353515625,
+        -0.0581054612994194,
+        -0.486328125,
+        0.8964843153953552,
+        -41.28612518310547,
+        44.89975357055664,
+        -28.282575607299805,
+        0.8715572357177734,
+        -0.22864609956741333,
+        -0.0807524248957634,
+        0.42613154649734497,
+    )
+    for a, b in zip(list(sensor.sample(ts[0]))[0], target_0):
+        assert a == b
+
+    target_100 = (
+        1726825503.8969738,
+        -4.8770904541015625,
+        -7.3375701904296875,
+        -2.0809173583984375,
+        -0.1308593600988388,
+        -0.4711913764476776,
+        0.85546875,
+        -37.98215103149414,
+        38.5346794128418,
+        -19.76430320739746,
+        0.897792398929596,
+        -0.2490871101617813,
+        -0.04740327596664429,
+        0.3601073622703552,
+    )
+    for a, b in zip(list(sensor.sample(ts[100]))[0], target_100):
+        assert a == b
+
+    target_1093 = (
+        1726825512.557629,
+        -7.07244873046875,
+        3.467559814453125,
+        -4.4002532958984375,
+        -0.0507812462747097,
+        -0.52880859375,
+        0.8588866591453552,
+        -41.224647521972656,
+        37.80641174316406,
+        -24.91761016845703,
+        0.8892564177513123,
+        -0.2597949504852295,
+        -0.07967071235179901,
+        0.3679431080818176,
+    )
+    for a, b in zip(list(sensor.sample(ts[1093]))[0], target_1093):
+        assert a == b
+
+
+def test_events(rec: nr.NeonRecording):
+    sensor = rec.events
+    ts = sensor.ts
+    assert len(sensor) == 2
+
+    target_0 = (1726825501.5430002, "recording.begin")
+    for a, b in zip(list(sensor.sample(ts[0]))[0], target_0):
+        assert a == b
+
+    target_1 = (1726825512.556, "recording.end")
+    for a, b in zip(list(sensor.sample(ts[1]))[0], target_1):
+        assert a == b
+
+
+def test_scene(rec: nr.NeonRecording):
+    sensor = rec.scene
+    ts = sensor.ts
+    assert len(sensor) == 306
+
+    target_0 = 150.85475729166666
+    a = list(sensor.sample(ts[0:1]))[0]
+    assert np.mean(a.bgr) == target_0
+
+    target_100 = 150.60516822916668
+    a = list(sensor.sample(ts[100:101]))[0]
+    assert np.mean(a.bgr) == target_100
+
+    target_305 = 146.23578055555555
+    a = list(sensor.sample(ts[305:306]))[0]
+    assert np.mean(a.bgr) == target_305
+
+
+def test_eye(rec: nr.NeonRecording):
+    sensor = rec.eye
+    ts = sensor.ts
+    assert len(sensor) == 1951
+
+    for i in [0, 100, 1950]:
+        a = list(sensor.sample(ts[i : i + 1]))[0]
+        print(f"{np.mean(a.bgr)},")
+
+    target_0 = 122.28241644965277
+    a = list(sensor.sample(ts[0:1]))[0]
+    assert np.mean(a.bgr) == target_0
+
+    target_100 = 121.9274269386574
+    a = list(sensor.sample(ts[100:101]))[0]
+    assert np.mean(a.bgr) == target_100
+
+    target_1950 = 134.1152298538773
+    a = list(sensor.sample(ts[1950:1951]))[0]
+    assert np.mean(a.bgr) == target_1950


### PR DESCRIPTION
This loads eye_state from the `eye_state.dtype` file if it exists. When older recs are loaded they will return `None` for fields that are missing, eg.

```python
In [2]: plnr.load('/recs/neon/rec_with_eyelid_data/').eye_state[0]
Out[2]: EyeStateRecord(abs_timestamp=1713345197748491979, rel_timestamp=2.367491979, pupil_diameter_left=3.57157, eyeball_center_left=(-29.77539, 19.326172, -33.3313), optical_axis_left=(-0.017957, 0.02676949, 0.99948037), pupil_diameter_right=3.6680305, eyeball_center_right=(33.222656, 19.746094, -35.270996), optical_axis_right=(-0.16169295, 0.00729824, 0.98681414), eyelid_angle=None, eyelid_aperture=None)

In [3]: plnr.load('/recs/neon/rec_without_eyelid_data/').eye_state[0]
Out[3]: EyeStateRecord(abs_timestamp=1736859564514212519, rel_timestamp=2.092212519, pupil_diameter_left=6.006512, eyeball_center_left=(-39.823914, 19.77539, -37.77893), optical_axis_left=(0.661439, -0.05428582, 0.7480318), pupil_diameter_right=5.7570925, eyeball_center_right=(39.110107, 18.535156, -42.961693), optical_axis_right=(0.10594358, -0.05825835, 0.9926641), eyelid_angle=(1.0478516, -0.7636719, 0.8959961, -0.95996094), eyelid_aperture=(20.483213, 20.973581))```