### PR TITLE
fix(utils): use correct dtype in case of empty timeseries

### DIFF
--- a/src/pupil_labs/neon_recording/utils.py
+++ b/src/pupil_labs/neon_recording/utils.py
@@ -34,7 +34,8 @@ def load_multipart_data_time_pairs(file_pairs, dtype):
 
     time_data = Array(ts_files, TIMESTAMP_DTYPE)  # type: ignore
     if not len(time_data):
-        return np.array([], dtype=TIMESTAMP_DTYPE)
+        return_dtype = np.dtype(TIMESTAMP_DTYPE.descr + dtype.descr)
+        return np.array([], dtype=return_dtype)
 
     if dtype == "str":
         data_bytes = b""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+from pupil_labs.neon_recording.utils import load_multipart_data_time_pairs
+
+
+def test_load_multipart_data_time_pairs_no_timestamps_dtype():
+    empty_time_data_arrays = [(np.array([]), np.array([]))]
+    dtype = np.dtype([("field1", "int64"), ("field2", "int64")])
+    data = load_multipart_data_time_pairs(empty_time_data_arrays, dtype)
+
+    assert list(data.dtype.fields) == ["time", "field1", "field2"]


### PR DESCRIPTION
Old dtype contained timestamp only and caused downstream errors in case of empty timeseries data, e.g., [here](https://github.com/pupil-labs/pl-neon-recording/blob/593731c6834dfd1c9eacc4041890148a9dbaee8b/src/pupil_labs/neon_recording/timeseries/blinks.py#L61).